### PR TITLE
Updatinging RenderTotals component

### DIFF
--- a/UI/src/components/RenderIconsandTotals.tsx
+++ b/UI/src/components/RenderIconsandTotals.tsx
@@ -14,12 +14,20 @@ export const RenderTotals = (props: {
   balance: number;
   accountNum: number;
   id: string;
+  onClick: string;
 }) => {
   const navigate = useNavigate();
   return (
     <div
       className={props.className}
-      onClick={() => navigate(`/dashboard-client/account-info/${props.id}`)}
+      onClick={
+        props.onClick === 'toAccountInfo'
+          ? () => navigate(`/dashboard-client/account-info/${props.id}`)
+          : () =>
+              navigate(
+                `/dashboard-client/account-info/${props?.id}/transactions/${props?.accountNum}`
+              )
+      }
     >
       <div className='total-info'>
         <h3>{`Account: ${props.accountNum}`}</h3>

--- a/UI/src/pages/ClientDashboard/ClientDashboard.tsx
+++ b/UI/src/pages/ClientDashboard/ClientDashboard.tsx
@@ -144,6 +144,7 @@ const ClientDashboard = (props: { handleLogout: () => void }) => {
                 accountNum={account.accountNumber}
                 className='total'
                 id={account.id}
+                onClick='toAccountInfo'
               />
             ))}
           </div>

--- a/UI/src/pages/Transaction/SelectAccount/SelectAccount.tsx
+++ b/UI/src/pages/Transaction/SelectAccount/SelectAccount.tsx
@@ -31,6 +31,7 @@ const SelectAccount = () => {
             accountNum={account.accountNumber}
             className='total'
             id={account.id}
+            onClick='toAccountAllTransactions'
           />
         ))}
       </div>


### PR DESCRIPTION
Reusing RenderTotals component so that when account is selected from the select accounts page that comes when user clicks transaction history on their dashboard, user is redirected straight to accounts history for that account selected and when user clicks on any of the displayed accounts on their dashboard, they're redirected to accountInfo page for that account clicked.