### PR TITLE
Staff Dashboard and All Accounts page update

### DIFF
--- a/UI/src/pages/StaffDashboard/StaffDashboard.tsx
+++ b/UI/src/pages/StaffDashboard/StaffDashboard.tsx
@@ -55,21 +55,7 @@ const StaffDashboard = (props: { handleLogout: () => void }) => {
               </div>
             </div>
             <div className='container'>
-              <div className='left'>
-                <div
-                  className='box one'
-                  onClick={() => navigate('/dashboard-staff/search/users')}
-                >
-                  All Accounts
-                </div>
-                <div
-                  className='box two'
-                  onClick={() => navigate('/dashboard-staff/search/users')}
-                >
-                  Debit Cards
-                </div>
-                {user?.isAdmin && <div className='box one'>All Staff</div>}
-              </div>
+              <div className='left'></div>
               <div className='right'>
                 <div
                   className='box two'
@@ -79,7 +65,7 @@ const StaffDashboard = (props: { handleLogout: () => void }) => {
                 </div>
                 <div
                   className='box one'
-                  onClick={() => navigate('/dashboard-staff/search/users')}
+                  onClick={() => navigate('/dashboard-staff/search/users/all')}
                 >
                   Manage Accounts
                 </div>

--- a/UI/src/pages/StaffDashboard/sections/Search.scss
+++ b/UI/src/pages/StaffDashboard/sections/Search.scss
@@ -8,6 +8,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: space-around;
+
   form {
     width: 90vw;
     display: flex;
@@ -24,7 +25,10 @@
       padding: 15px;
       border-radius: 25px;
       background: $backgroundColor;
-      border: none;
+      // outline: none;
+      &:focus {
+        outline: none;
+      }
       &::placeholder {
         font-family: inherit;
         color: $grey-400;

--- a/UI/src/pages/StaffDashboard/sections/Search.tsx
+++ b/UI/src/pages/StaffDashboard/sections/Search.tsx
@@ -10,14 +10,32 @@ const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
 };
 
 const Search = () => {
+  const [user, setUser] = useState<User>();
   const [users, setUsers] = useState<Array<User>>([]);
   const [accounts, setAccounts] = useState<Array<Account>>([]);
   const [showAll, setShowAll] = useState(true);
   const [search, setSearch] = useState('');
+
   useEffect(() => {
-    userService.getAll().then((users) => setUsers(users));
     accountsService.getAll().then((accounts) => setAccounts(accounts));
+
+    const loggedUserJSON = window.localStorage.getItem('loggedAppUser');
+    if (loggedUserJSON) {
+      const retrivedUser = JSON.parse(loggedUserJSON);
+      setUser(retrivedUser);
+      userService
+        .getAll()
+        .then((users) =>
+          setUsers(
+            retrivedUser.isAdmin
+              ? users
+              : users.filter((user: User) => user.type !== 'staff')
+          )
+        );
+    }
   }, []);
+
+  console.log(user);
 
   const usersToShow = showAll
     ? users


### PR DESCRIPTION
Since only admins can when a cashier navigates to the search or all accounts page, they o=can only see client accounts while admins can see all accounts: cashier, client and even other admin accounts.
Updating cashier dashboard and removing redundant links like all accounts and debit cards since the manage account link can do the same thing.