### PR TITLE
Account Checks Before Transaction (bill payments, sports wallet funding, transfer and mobile top up pages). Notification (open account page), Route to Account Info page (Client dashboard notifications dropdpwn)

### DIFF
--- a/UI/src/pages/ClientDashboard/ClientDashboard.tsx
+++ b/UI/src/pages/ClientDashboard/ClientDashboard.tsx
@@ -133,6 +133,8 @@ const ClientDashboard = (props: { handleLogout: () => void }) => {
         )
       : oldNotification.message.includes('personal data')
       ? navigate(`/dashboard-client/${user?.id}/change-personal-data`)
+      : oldNotification.message.includes('a new account')
+      ? navigate(`/dashboard-client/account-info/${oldNotification?.accountId}`)
       : console.log('happiness');
   };
 
@@ -154,6 +156,8 @@ const ClientDashboard = (props: { handleLogout: () => void }) => {
         )
       : newNotification.message.includes('personal data')
       ? navigate(`/dashboard-client/${user?.id}/change-personal-data`)
+      : newNotification.message.includes('a new account')
+      ? navigate(`/dashboard-client/account-info/${newNotification?.accountId}`)
       : console.log('happiness');
   };
 

--- a/UI/src/pages/ClientDashboard/sections/BillPayments/BillPayments.tsx
+++ b/UI/src/pages/ClientDashboard/sections/BillPayments/BillPayments.tsx
@@ -100,9 +100,9 @@ const BillPayments = () => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (accountToShow?.status === 'active') {
-      if (accountToShow.balance >= Number(paymentDetails.amount)) {
-        if (user?.transferPin === paymentDetails.pin) {
+    if (user?.transferPin === paymentDetails.pin) {
+      if (accountToShow?.status === 'active') {
+        if (accountToShow.balance >= Number(paymentDetails.amount)) {
           const updatedSendingAccount = {
             ...accountToShow,
             balance:
@@ -159,22 +159,22 @@ const BillPayments = () => {
             phoneNumber: '',
           });
         } else {
-          toast.error('Wrong transfer pin', {
+          toast.error('Insufficient balance', {
             position: 'top-center',
           });
         }
       } else {
-        toast.error('Insufficient balance', {
-          position: 'top-center',
-        });
+        toast.error(
+          'Your account is not active. Please visit our branch near you to reactivate',
+          {
+            position: 'top-center',
+          }
+        );
       }
     } else {
-      toast.error(
-        'Your account is not active. Please visit our branch near you to reactivate',
-        {
-          position: 'top-center',
-        }
-      );
+      toast.error('Wrong transfer pin', {
+        position: 'top-center',
+      });
     }
   };
 

--- a/UI/src/pages/ClientDashboard/sections/SportWalletFunding/SportWalletFunding.tsx
+++ b/UI/src/pages/ClientDashboard/sections/SportWalletFunding/SportWalletFunding.tsx
@@ -86,9 +86,9 @@ const SportWalletFunding = () => {
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (accountToShow?.status === 'active') {
-      if (accountToShow.balance >= Number(paymentDetails.amount)) {
-        if (user?.transferPin === paymentDetails.pin) {
+    if (user?.transferPin === paymentDetails.pin) {
+      if (accountToShow?.status === 'active') {
+        if (accountToShow.balance >= Number(paymentDetails.amount)) {
           const updatedSendingAccount = {
             ...accountToShow,
             balance:
@@ -144,22 +144,22 @@ const SportWalletFunding = () => {
             phoneNumber: '',
           });
         } else {
-          toast.error('Wrong transfer pin', {
+          toast.error('Insufficient balance', {
             position: 'top-center',
           });
         }
       } else {
-        toast.error('Insufficient balance', {
-          position: 'top-center',
-        });
+        toast.error(
+          'Your account is not active. Please visit our branch near you to reactivate',
+          {
+            position: 'top-center',
+          }
+        );
       }
     } else {
-      toast.error(
-        'Your account is not active. Please visit our branch near you to reactivate',
-        {
-          position: 'top-center',
-        }
-      );
+      toast.error('Wrong transfer pin', {
+        position: 'top-center',
+      });
     }
   };
 

--- a/UI/src/pages/ClientDashboard/sections/TransferPage/Transfer.tsx
+++ b/UI/src/pages/ClientDashboard/sections/TransferPage/Transfer.tsx
@@ -130,166 +130,170 @@ const Transfer = () => {
     let creditMessage: string;
     let creditId: string;
 
-    // if (accountToShow.balance >= Number(topupDetails.amount)) {
-    // } else {
-    //   toast.error('Insufficient balance', {
-    //     position: 'top-center',
-    //   });
-    // }
-
     if (accountForTransfer) {
       if (user?.transferPin === transferPin) {
         if (sendingAccount?.status === 'active') {
-          if (receivingAccount) {
-            const updatedSendingAccount = {
-              ...sendingAccount,
-              balance:
-                sendingAccount &&
-                sendingAccount?.balance - Number(transferDetials.amount),
-            };
+          if (sendingAccount.balance >= Number(transferDetials.amount)) {
+            if (receivingAccount) {
+              const updatedSendingAccount = {
+                ...sendingAccount,
+                balance:
+                  sendingAccount &&
+                  sendingAccount?.balance - Number(transferDetials.amount),
+              };
 
-            const updatedRecievingAccount = {
-              ...receivingAccount,
-              balance:
-                receivingAccount &&
-                receivingAccount?.balance + Number(transferDetials.amount),
-            };
+              const updatedRecievingAccount = {
+                ...receivingAccount,
+                balance:
+                  receivingAccount &&
+                  receivingAccount?.balance + Number(transferDetials.amount),
+              };
 
-            accountService
-              .debit(sendingAccount?.id, updatedSendingAccount)
-              .then((response) => console.log(response));
+              accountService
+                .debit(sendingAccount?.id, updatedSendingAccount)
+                .then((response) => console.log(response));
 
-            accountService
-              .credit(receivingAccount?.id, updatedRecievingAccount)
-              .then((response) => console.log(response));
+              accountService
+                .credit(receivingAccount?.id, updatedRecievingAccount)
+                .then((response) => console.log(response));
 
-            const newCreditTransaction: NewTransaction = {
-              accountNumber: receivingAccount?.accountNumber,
-              createdOn: new Date(),
-              type: 'credit',
-              amount: Number(transferDetials.amount),
-              oldBalance: receivingAccount?.balance,
-              newBalance: updatedRecievingAccount.balance,
-              description: `Frm:${user.firstName} ${user.lastName}, ${transferDetials.bankName}Mobile; ${transferDetials.description}`,
-            };
+              const newCreditTransaction: NewTransaction = {
+                accountNumber: receivingAccount?.accountNumber,
+                createdOn: new Date(),
+                type: 'credit',
+                amount: Number(transferDetials.amount),
+                oldBalance: receivingAccount?.balance,
+                newBalance: updatedRecievingAccount.balance,
+                description: `Frm:${user.firstName} ${user.lastName}, ${transferDetials.bankName}Mobile; ${transferDetials.description}`,
+              };
 
-            const newDebitTransaction: NewTransaction = {
-              accountNumber: sendingAccount?.accountNumber,
-              createdOn: new Date(),
-              type: 'debit',
-              amount: Number(transferDetials.amount),
-              oldBalance: sendingAccount?.balance,
-              newBalance: updatedSendingAccount.balance,
-              description: `To:${receivingAccountOwner?.firstName} ${receivingAccountOwner?.lastName}, ${transferDetials.bankName}Mobile; ${transferDetials.description}`,
-            };
+              const newDebitTransaction: NewTransaction = {
+                accountNumber: sendingAccount?.accountNumber,
+                createdOn: new Date(),
+                type: 'debit',
+                amount: Number(transferDetials.amount),
+                oldBalance: sendingAccount?.balance,
+                newBalance: updatedSendingAccount.balance,
+                description: `To:${receivingAccountOwner?.firstName} ${receivingAccountOwner?.lastName}, ${transferDetials.bankName}Mobile; ${transferDetials.description}`,
+              };
 
-            transactionsService
-              .newCreditTransaction(newCreditTransaction)
-              .then((creditTransaction) => {
-                // console.log(creditTransaction);
-                if (
-                  receivingAccountNotificationBox ===
-                  sendingAccountNotificationBox
-                ) {
-                  creditMessage = creditTransaction.description;
-                  creditId = creditTransaction.id;
-                } else {
-                  if (receivingAccountNotificationBox) {
-                    const creditNotification: Notification = {
-                      ...receivingAccountNotificationBox,
-                      newNotifications:
-                        receivingAccountNotificationBox?.newNotifications.concat(
-                          {
-                            message: creditTransaction.description,
+              transactionsService
+                .newCreditTransaction(newCreditTransaction)
+                .then((creditTransaction) => {
+                  // console.log(creditTransaction);
+                  if (
+                    receivingAccountNotificationBox ===
+                    sendingAccountNotificationBox
+                  ) {
+                    creditMessage = creditTransaction.description;
+                    creditId = creditTransaction.id;
+                  } else {
+                    if (receivingAccountNotificationBox) {
+                      const creditNotification: Notification = {
+                        ...receivingAccountNotificationBox,
+                        newNotifications:
+                          receivingAccountNotificationBox?.newNotifications.concat(
+                            {
+                              message: creditTransaction.description,
+                              accountId: receivingAccount.id,
+                              accountNumber: receivingAccount.accountNumber,
+                              transactionId: creditTransaction.id,
+                            }
+                          ),
+                      };
+
+                      notificationsService
+                        .updateNotification(
+                          receivingAccountNotificationBox?.id,
+                          creditNotification
+                        )
+                        .then((response) => console.log(response));
+                    }
+                  }
+                });
+
+              transactionsService
+                .newDebitTransaction(newDebitTransaction)
+                .then((debitTransaction) => {
+                  // console.log(debitTransaction);
+                  if (
+                    receivingAccountNotificationBox ===
+                    sendingAccountNotificationBox
+                  ) {
+                    if (sendingAccountNotificationBox) {
+                      const debitNotification: Notification = {
+                        ...sendingAccountNotificationBox,
+                        newNotifications:
+                          sendingAccountNotificationBox?.newNotifications.concat(
+                            {
+                              message: debitTransaction.description,
+                              accountId: sendingAccount.id,
+                              accountNumber: sendingAccount.accountNumber,
+                              transactionId: debitTransaction.id,
+                            }
+                          ),
+                      };
+                      const creditNotification: Notification = {
+                        ...debitNotification,
+                        newNotifications:
+                          debitNotification.newNotifications.concat({
+                            message: creditMessage,
                             accountId: receivingAccount.id,
                             accountNumber: receivingAccount.accountNumber,
-                            transactionId: creditTransaction.id,
-                          }
-                        ),
-                    };
+                            transactionId: creditId,
+                          }),
+                      };
 
-                    notificationsService
-                      .updateNotification(
-                        receivingAccountNotificationBox?.id,
-                        creditNotification
-                      )
-                      .then((response) => console.log(response));
+                      notificationsService
+                        .updateNotification(
+                          receivingAccountNotificationBox?.id,
+                          creditNotification
+                        )
+                        .then((response) => console.log(response));
+                    }
+                  } else {
+                    if (sendingAccountNotificationBox) {
+                      const debitNotification: Notification = {
+                        ...sendingAccountNotificationBox,
+                        newNotifications:
+                          sendingAccountNotificationBox?.newNotifications.concat(
+                            {
+                              message: debitTransaction.description,
+                              accountId: sendingAccount.id,
+                              accountNumber: sendingAccount.accountNumber,
+                              transactionId: debitTransaction.id,
+                            }
+                          ),
+                      };
+
+                      notificationsService
+                        .updateNotification(
+                          sendingAccountNotificationBox?.id,
+                          debitNotification
+                        )
+                        .then((response) => console.log(response));
+                    }
                   }
-                }
+                });
+
+              navigate('/dashboard-client');
+
+              setTransferDetials({
+                ...transferDetials,
+                bankName: '',
+                amount: '',
+                accountNumber: '',
               });
-
-            transactionsService
-              .newDebitTransaction(newDebitTransaction)
-              .then((debitTransaction) => {
-                // console.log(debitTransaction);
-                if (
-                  receivingAccountNotificationBox ===
-                  sendingAccountNotificationBox
-                ) {
-                  if (sendingAccountNotificationBox) {
-                    const debitNotification: Notification = {
-                      ...sendingAccountNotificationBox,
-                      newNotifications:
-                        sendingAccountNotificationBox?.newNotifications.concat({
-                          message: debitTransaction.description,
-                          accountId: sendingAccount.id,
-                          accountNumber: sendingAccount.accountNumber,
-                          transactionId: debitTransaction.id,
-                        }),
-                    };
-                    const creditNotification: Notification = {
-                      ...debitNotification,
-                      newNotifications:
-                        debitNotification.newNotifications.concat({
-                          message: creditMessage,
-                          accountId: receivingAccount.id,
-                          accountNumber: receivingAccount.accountNumber,
-                          transactionId: creditId,
-                        }),
-                    };
-
-                    notificationsService
-                      .updateNotification(
-                        receivingAccountNotificationBox?.id,
-                        creditNotification
-                      )
-                      .then((response) => console.log(response));
-                  }
-                } else {
-                  if (sendingAccountNotificationBox) {
-                    const debitNotification: Notification = {
-                      ...sendingAccountNotificationBox,
-                      newNotifications:
-                        sendingAccountNotificationBox?.newNotifications.concat({
-                          message: debitTransaction.description,
-                          accountId: sendingAccount.id,
-                          accountNumber: sendingAccount.accountNumber,
-                          transactionId: debitTransaction.id,
-                        }),
-                    };
-
-                    notificationsService
-                      .updateNotification(
-                        sendingAccountNotificationBox?.id,
-                        debitNotification
-                      )
-                      .then((response) => console.log(response));
-                  }
-                }
-              });
-
-            navigate('/dashboard-client');
-
-            setTransferDetials({
-              ...transferDetials,
-              bankName: '',
-              amount: '',
-              accountNumber: '',
-            });
+            } else {
+              setAccountErrorMessage(
+                `Can't find account with account number ${transferDetials.accountNumber}`
+              );
+            }
           } else {
-            setAccountErrorMessage(
-              `Can't find account with account number ${transferDetials.accountNumber}`
-            );
+            toast.error('Insufficient balance', {
+              position: 'top-center',
+            });
+            setOpenConfirm(false);
           }
         } else {
           toast.error(


### PR DESCRIPTION
Changing the order of checks (bill payments, sports wallet funding and mobile top up pages) carried out before transaction. Transfer pin is checked first, then account status is checked next and finally account balance is checked, Adding a new check (transfer page) to make sure an account to transfer from is selected as well as changing the order of checks carried out before transaction. Transfer pin is checked first, then account status is checked next, Adding a new check to make sure the transferring account's balance is sufficient for the transaction (transfer page), A notification is sent to a client after he/she create a new account, Clicking on a new or old notification of an opened account leads to account info page