### PR TITLE
Account Info Page (transfer button), Transfer Page (back arrow navigation)

### DIFF
--- a/UI/src/pages/ClientDashboard/sections/AccountInfo/AccountInfo.scss
+++ b/UI/src/pages/ClientDashboard/sections/AccountInfo/AccountInfo.scss
@@ -55,7 +55,7 @@
         overflow: hidden;
 
         div {
-          width: 30%;
+          width: 25%;
           height: 100%;
           background: #e1dcd9;
           padding: 0.75em;
@@ -69,6 +69,12 @@
           .content {
             width: 100%;
             text-align: center;
+          }
+
+          .item {
+            margin-bottom: -5px;
+            cursor: pointer;
+            transform: scale(1.5);
           }
         }
       }

--- a/UI/src/pages/ClientDashboard/sections/AccountInfo/AccountInfo.tsx
+++ b/UI/src/pages/ClientDashboard/sections/AccountInfo/AccountInfo.tsx
@@ -6,6 +6,7 @@ import TextSnippetIcon from '@mui/icons-material/TextSnippet';
 import HistoryIcon from '@mui/icons-material/History';
 // import { RenderIcons } from '../../components/RenderIconsandTotals';
 import { useNavigate } from 'react-router-dom';
+import { RenderIcons } from '../../../../components/RenderIconsandTotals';
 
 const AccountInfo = (props: { account: Account | null | undefined }) => {
   const navigate = useNavigate();
@@ -57,15 +58,17 @@ const AccountInfo = (props: { account: Account | null | undefined }) => {
         </div>
         <div className='body'>
           <div className='buttons-container'>
-            {/* <div>
+            <div>
               <RenderIcons
-                label='Transfer'
-                icon='./assets/icons8-money-transfer-48.png'
+                label=''
+                icon='../../assets/icons8-money-transfer-48.png'
                 onClick={() =>
                   navigate(`/dashboard-client/${user?.id}/transfer`)
                 }
+                className='item'
               />
-            </div> */}
+              <div className='content'>Transfer</div>
+            </div>
             <div>
               {<TextSnippetIcon fontSize='large' />}
               <div className='content'>Generate Statement</div>

--- a/UI/src/pages/ClientDashboard/sections/TransferPage/Transfer.tsx
+++ b/UI/src/pages/ClientDashboard/sections/TransferPage/Transfer.tsx
@@ -337,10 +337,7 @@ const Transfer = () => {
   return (
     <div className='transfer'>
       <div className='top'>
-        <ArrowBackIcon
-          className='back-icon'
-          onClick={() => navigate('/dashboard-client')}
-        />
+        <ArrowBackIcon className='back-icon' onClick={() => navigate(-1)} />
         <h2>Transfer</h2>
       </div>
       <div className={'confirm-container ' + (openConfirm && 'active')}>


### PR DESCRIPTION
Back arrow in the top box of transfer page navigates back to the immediately previous page and not to client dashboard, Adding a transfer button to the accounts info page and styling that button.