### PR TITLE
Error Handler Middleware Updated

### DIFF
--- a/Api/src/utils/middleware.ts
+++ b/Api/src/utils/middleware.ts
@@ -24,6 +24,17 @@ const errorHandler: ErrorRequestHandler = (error, _request, response, next) => {
     return response.status(400).send({ error: 'malformatted id' });
   } else if (error.name === 'ValidationError') {
     return response.status(400).json({ error: error.message });
+  } else if (
+    error.name === 'MongoServerError' &&
+    error.message.includes('E11000 duplicate key error')
+  ) {
+    return response
+      .status(400)
+      .json({ error: 'expected `email` to be unique' });
+  } else if (error.name === 'JsonWebTokenError') {
+    return response.status(401).json({ error: 'token invalid' });
+  } else if (error.name === 'TokenExpiredError') {
+    return response.status(401).json({ error: 'token expired' });
   }
 
   next(error);


### PR DESCRIPTION
Updating the error handler middleware to cater for MongoServerError for when an already existing email is used in creating a new user account, jsonwebtokenerror for when a bad or invalid token is used and tokenexpired error for when an expires token is used for operation.