### PR TITLE
Contact Page (routing to our history page)

### DIFF
--- a/UI/src/pages/HomePage/sections/contact/Contact.tsx
+++ b/UI/src/pages/HomePage/sections/contact/Contact.tsx
@@ -138,7 +138,7 @@ const Contact = () => {
             </div>
             <div className={'service-list-box ' + (aboutUsOpen && 'active')}>
               <ul>
-                <li>Our History</li>
+                <li onClick={() => navigate('/our-history')}>Our History</li>
                 <li>Corporate profile</li>
                 <li>Board and Management Team</li>
               </ul>


### PR DESCRIPTION
Clicking our history in the contact section of the home page sends user to the our history page.