### PR TITLE
Client Dashboard (profile icon updated)

### DIFF
--- a/UI/src/pages/ClientDashboard/ClientDashboard.tsx
+++ b/UI/src/pages/ClientDashboard/ClientDashboard.tsx
@@ -250,12 +250,20 @@ const ClientDashboard = (props: { handleLogout: () => void }) => {
                 {notificationCount}
               </div>
             </div>
-            <div className='account-icon-container'>
-              <AccountCircleIcon
-                fontSize='large'
-                className='account-icon'
-                onClick={handleProfileClick}
-              />
+            <div
+              className='account-icon-container'
+              onClick={handleProfileClick}
+            >
+              {!user?.profilePicture ? (
+                <AccountCircleIcon fontSize='large' className='account-icon' />
+              ) : (
+                <div className={'profile-photo'}>
+                  <img
+                    src={`http://localhost:3001/${user?.profilePicture}`}
+                    alt=''
+                  />
+                </div>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Updating the client dashboard profile icon. If the logged in user has a profile photo uploaded, their profile photo is displayed instead of the generic profile icon but if the user doesn't have a profile picture, the generic profile icon is displayed.