### PR TITLE
Authorization Header added to Delete in Accounts Services

### DIFF
--- a/UI/src/services/accounts.ts
+++ b/UI/src/services/accounts.ts
@@ -44,7 +44,9 @@ const updateAccount = async (id: string, updatedAccount: Account) => {
 };
 
 const deleteAccount = async (id: string) => {
-  const response = await axios.delete(`${baseUrl}/${id}`);
+  const config = { headers: { Authorization: token } };
+
+  const response = await axios.delete(`${baseUrl}/${id}`, config);
 
   return response.data;
 };


### PR DESCRIPTION
Adding a token to the header of the delete account operation so that only logged in user with a valid token can delete an account.