### PR TITLE
Account Page (deleting user delete's their bar chart info)

### DIFF
--- a/UI/src/pages/AccountPage/AccountPage.tsx
+++ b/UI/src/pages/AccountPage/AccountPage.tsx
@@ -119,6 +119,12 @@ const AccountPage = (props: { user: User | null | undefined }) => {
           .then((response) => console.log(response));
       }
 
+      if (userBarChartInfo) {
+        incomeExpenseService
+          .deleteBarChartInfo(userBarChartInfo?.id)
+          .then((response) => console.log(response));
+      }
+
       if (id) {
         usersService.deleteUser(id).then((response) => {
           if (loggedInStaffNotificationBox) {


### PR DESCRIPTION
Deleting a user's account by the staff also deletes the user's bar chart info.