### PR TITLE
Home Page, Contact Section (routing to corporate profile)

### DIFF
--- a/UI/src/pages/HomePage/sections/contact/Contact.tsx
+++ b/UI/src/pages/HomePage/sections/contact/Contact.tsx
@@ -141,7 +141,9 @@ const Contact = () => {
             <div className={'service-list-box ' + (aboutUsOpen && 'active')}>
               <ul>
                 <li onClick={() => navigate('/our-history')}>Our History</li>
-                <li>Corporate profile</li>
+                <li onClick={() => navigate('corporate-profile')}>
+                  Corporate profile
+                </li>
                 <li>Board and Management Team</li>
               </ul>
             </div>


### PR DESCRIPTION
Clicking the corporate profile link in the contact section of the home page sends the user to the corporate profile page.