### PR TITLE
Home Page, Contact Section (routing to support center)

### DIFF
--- a/UI/src/pages/HomePage/sections/contact/Contact.tsx
+++ b/UI/src/pages/HomePage/sections/contact/Contact.tsx
@@ -116,7 +116,9 @@ const Contact = () => {
             <div className={'service-list-box ' + (quickLinksOpen && 'active')}>
               <ul>
                 <li>Online Banking</li>
-                <li>Support Center</li>
+                <li onClick={() => navigate('/support-center')}>
+                  Support Center
+                </li>
                 <li onClick={() => navigate('/report-scam')}>
                   Report Scam and Fraud Attempts
                 </li>


### PR DESCRIPTION
Clicking the support center link in the contact section of the home page sends the user to the support center page.