### PR TITLE
Open Account Page (change form select label position)

### DIFF
--- a/UI/src/pages/ClientDashboard/sections/OpenAccount/OpenAccount.tsx
+++ b/UI/src/pages/ClientDashboard/sections/OpenAccount/OpenAccount.tsx
@@ -176,7 +176,6 @@ const OpenAccount = () => {
       <form className='form' onSubmit={handleSubmit}>
         <strong className='form-header'>Open An Account</strong>
         <div className='form-header-seperator'></div>
-        <label htmlFor='isAdmin'>Account Type</label>
         <select
           name='isAmin'
           id='isAmin'
@@ -184,6 +183,7 @@ const OpenAccount = () => {
           className='form-select'
           onChange={(e) => setAccountType(e.target.value)}
         >
+          <option value='savings'>Account Type</option>
           <option value='savings'>Savings</option>
           <option value='current'>Current</option>
         </select>


### PR DESCRIPTION
Updating form select for account type in the open account page. The label is now within the select box.