### PR TITLE
Displaying profile picture is done differently in client dashboard

### DIFF
--- a/UI/src/pages/ClientDashboard/ClientDashboard.tsx
+++ b/UI/src/pages/ClientDashboard/ClientDashboard.tsx
@@ -258,10 +258,7 @@ const ClientDashboard = (props: { handleLogout: () => void }) => {
                 <AccountCircleIcon fontSize='large' className='account-icon' />
               ) : (
                 <div className={'profile-photo'}>
-                  <img
-                    src={`http://localhost:3001/${user?.profilePicture}`}
-                    alt=''
-                  />
+                  <img src={`${user?.profilePicture}`} alt='' />
                 </div>
               )}
             </div>


### PR DESCRIPTION
Displaying profile picture is done differently in client dashboard as profile picture url has changed as profile pictures are now uploaded to firebase.